### PR TITLE
feat: optional file pattern to prevent indexing certain files

### DIFF
--- a/cmd/gindex/repo.go
+++ b/cmd/gindex/repo.go
@@ -97,9 +97,15 @@ func indexCommit(cfg *Configuration, commit *gig.Commit, repoid string, commitid
 		}
 		if !hasBlob {
 			bpath, _ := GetBlobPath(blid.String(), commitid.String(), path)
-			err = NewBlobFromGig(blob, repoid, blid, commitid.String(), bpath, reponame).AddToIndexTimeout(cfg, blid)
-			if err != nil {
-				log.Debugf("Indexing blob failed: %v", err)
+			if cfg.ExcludePattern.glob != nil && bpath != "" && cfg.ExcludePattern.glob.Match(bpath) {
+				//do not index file that match exclusion pattern
+				log.Debugf("NOT indexing blob : %s", bpath)
+			} else {
+				log.Debugf("Indexing blob : %s ", bpath)
+				err = NewBlobFromGig(blob, repoid, blid, commitid.String(), bpath, reponame).AddToIndexTimeout(cfg, blid)
+				if err != nil {
+					log.Debugf("Indexing blob failed: %v", err)
+				}
 			}
 		} else {
 			log.Debugf("Blob there :%s", blid)

--- a/cmd/gindex/util.go
+++ b/cmd/gindex/util.go
@@ -143,6 +143,7 @@ func GetBlobPath(blid, cid, path string) (string, error) {
 	cmd := git.NewCommand("ls-tree", "-r", cid)
 	res, err := cmd.RunInDirBytes(path)
 	if err != nil {
+		log.Errorf("GetBlobPath: Could not find path for blob: %s\ngit ls-tree error: %+v", blid, err)
 		return "", err
 	}
 	pattern := fmt.Sprintf("%s\\s+(.+)", blid)

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/go-macaron/cache v0.0.0-20151013081102-561735312776 // indirect
 	github.com/go-macaron/inject v0.0.0-20160627170012-d8a0b8677191 // indirect
 	github.com/go-macaron/session v0.0.0-20190131233854-0a0a789bf193 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogits/go-gogs-client v0.0.0-20190616193657-5a05380e4bc2
 	github.com/gogs/chardet v0.0.0-20150115103509-2404f7772561 // indirect
 	github.com/gogs/go-libravatar v0.0.0-20161120025154-cd1abbd55d09 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/go-macaron/inject v0.0.0-20160627170012-d8a0b8677191 h1:NjHlg70DuOkcA
 github.com/go-macaron/inject v0.0.0-20160627170012-d8a0b8677191/go.mod h1:VFI2o2q9kYsC4o7VP1HrEVosiZZTd+MVT3YZx4gqvJw=
 github.com/go-macaron/session v0.0.0-20190131233854-0a0a789bf193 h1:z/nqwd+ql/r6Q3QGnwNd6B89UjPytM0be5pDQV9TuWw=
 github.com/go-macaron/session v0.0.0-20190131233854-0a0a789bf193/go.mod h1:ScEJm9Gk+ez5JJTml5WlBIqavAfuE5nF8e4Gvyz/X+A=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gogits/go-gogs-client v0.0.0-20190616193657-5a05380e4bc2 h1:BbwX8wsMRDZRdNYxAna+4ls3wvMKJyn4PT6Zk1CPxP4=
 github.com/gogits/go-gogs-client v0.0.0-20190616193657-5a05380e4bc2/go.mod h1:cY2AIrMgHm6oOHmR7jY+9TtjzSjQ3iG7tURJG3Y6XH0=
 github.com/gogs/chardet v0.0.0-20150115103509-2404f7772561 h1:aBzukfDxQlCTVS0NBUjI5YA3iVeaZ9Tb5PxNrrIP1xs=


### PR DESCRIPTION
**Feature proposal**: Add an optional file pattern to prevent indexing certain files, by checking their path.

It can solve #1, and similar situation in a generic way: It allows preventing to pollute the blob index with some technical text file (such as DataLad internal files) that have no added values for data text search.

Usage: like other configuration parameters, the pattern is set via an environment variable (`exclude_from_index`), and it uses [glob syntax](https://pkg.go.dev/github.com/gobwas/glob#Compile).
e.g. to prevent indexing SVGs and DataLad's internal files set the variable to  :  
```sh
exclude_from_index={**.svg,**.gitattributes,.datalad**}
```